### PR TITLE
Broken Link: Barabási and Albert Network Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ Inspired by [Awesome Deep Learning](https://github.com/ChristosChristofidis/awes
 
 ## Datasets
 
--   [Barabási and Albert Network Datasets](https://www3.nd.edu/~networks/resources.htm).
 -   [Bayesian Network Repository](http://www.bnlearn.com/bnrepository/).
 -   [Bill Cosponsorship Networks in European Parliaments](https://github.com/briatte/parlnet) - Legislative cosponsorship networks, in R format.
 -   [Colorado Index of Complex Networks (ICON)](https://icon.colorado.edu/) - Large collection of networks described and indexed by Aaron Clauset's research group.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Inspired by [Awesome Deep Learning](https://github.com/ChristosChristofidis/awes
 -   [Manlio De Domenico’s Multilayer Networks](http://deim.urv.cat/~manlio.dedomenico/data.php).
 -   [Mark E.J. Newman’s Network Data](http://www-personal.umich.edu/~mejn/netdata/) ([example visualizations](http://www-personal.umich.edu/~mejn/networks/)).
 -   [Network Repository](http://networkrepository.com/) - Fully searchable database containing hundreds of real-world networks.
+-   [Network Science Book - Network Datasets](http://networksciencebook.com/translations/en/resources/data.html) - Network data sets from the book Network Science by Albert-László Barabási. Includes data on IMDB actors, arXiv scientific collaboration, network of routers, US power grid, protein-protein interaction, cell phone users, citation network, metabolic reactions, e-mail network, and nd.edu web pages.
 -   [Nexus](http://nexus.igraph.org/) - Repository of network datasets in GraphML and igraph formats.
 -   [Norwegian Interlocking Directorate, 2002-2011](http://www.boardsandgender.com/data.php) - Two-mode and one-mode data on gender representation in Norwegian firms.
 -   [Movie galaxies](http://moviegalaxies.com/) - A databse of movie characters interaction graphs.


### PR DESCRIPTION
Removed broken link to https://www3.nd.edu/~networks/resources.htm and added link to http://networksciencebook.com/translations/en/resources/data.html which may contain some of the data originally hosted in the nd.edu site. Also added a short description on the new link in support of issue #46.