### PR TITLE
Fix Dataset Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ __Note:__ searching for ‘@’ will return all Twitter accounts listed on this 
 -   [Eric D. Kolaczyk’s Network Datasets](http://math.bu.edu/people/kolaczyk/datasets.html).
 -   [Gephi Datasets](https://github.com/gephi/gephi/wiki/Datasets).
 -   [igraphdata](https://CRAN.R-project.org/package=igraphdata) - R data-centric package.
--   [Interaction Web Database](https://www.nceas.ucsb.edu/interactionweb/resources.html) - Ecological species interactions.
+-   [Interaction Web Database](http://www.ecologia.ib.usp.br/iwdb/) - Ecological species interactions.
 -   [International Currencies 1890-1910](http://eh.net/database/international-currencies-1890-1910/) - Historical data on the international connections between 45 currencies.
 -   [KONECT - The Koblenz Network Collection](http://konect.uni-koblenz.de/) - Includes, among other things, networks of collaboration in DBpedia and Wikipedia, GitHub ([companion handbook](http://arxiv.org/abs/1402.5500)).
 -   [James H. Fowler’s Cosponsorship Network Data Page](http://jhfowler.ucsd.edu/cosponsorship.htm).


### PR DESCRIPTION
The dataset has been moved to the site (http://www.ecologia.ib.usp.br/iwdb/) that is maintained by University of São Paulo, Brazil now.