### PR TITLE
Add gdMetriX as NetworkX sub-entry in Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ Inspired by [Awesome Deep Learning](https://github.com/ChristosChristofidis/awes
 -   [littleballoffur](https://github.com/benedekrozemberczki/littleballoffur) - Python package for sampling from graph structured data with a scikit-learn like API.
 -   [metaknowledge](http://networkslab.org/metaknowledge/) - Python package to turn bibliometrics data into authorship and citation networks.
 -   [networkx](https://networkx.org/) - Python package for the creation, manipulation, and study of the structure, dynamics, and functions of complex networks.
+    -   [gdMetriX](https://github.com/livus/gdMetriX) - NetworkX extension for computing graph drawing quality metrics (crossings, symmetry, node distribution, edge directions, and more).
     -   [Implementing an ERGM from Scratch in Python](https://gist.github.com/dmasad/8509304), using networkx and numpy (2014).
     -   [nxviz](https://github.com/ericmjl/nxviz/) - Visualization package for NetworkX.
 -   [nngt](https://nngt.readthedocs.io) - Library-agnostic graph generation and analysis that wraps around `networkx`, `igraph` and `graph-tool`). Includes normalized graph measures, advanced visualizations, (geo)spatial tools, and interfaces for neuroscience simulators.
@@ -1033,8 +1034,9 @@ Alden S. Klovdahl,
 [Benjamin Smith](https://github.com/benyamindsmith), 
 [Beth Duckles](https://github.com/bduckles), 
 [Lei Cao](https://github.com/cllei12), 
-[Simon Delarue](https://www.simondelarue.com/) and 
-[Christian Schulz](https://schulzchristian.github.io/) - 
+[Simon Delarue](https://www.simondelarue.com/), 
+[Christian Schulz](https://schulzchristian.github.io/) and
+[Sebastian Röder](https://github.com/livus) - 
 have waived all copyright and related or neighboring rights to this work.
 
 Thanks to [Robert J. Ackland](https://github.com/rjackland), 


### PR DESCRIPTION
gdMetriX extends networkX by analysis tools for network visualitations and graph drawings. Examples are an efficient crossing detection algorithm or symmetry detections. The repo can be found [here](https://github.com/livus/gdMetriX).